### PR TITLE
Enhance valid_hooks to Prevent all([]) and add tests

### DIFF
--- a/guet/git/_all_valid_hooks.py
+++ b/guet/git/_all_valid_hooks.py
@@ -28,15 +28,26 @@ def all_valid_hooks(hooks: List[Hook]) -> bool:
 
 
 def valid_hooks(hooks: List[Hook]) -> List[Hook]:
-    hook_names = [_name(hook) for hook in _normal_hooks(hooks)]
-    valid_names = GUET_HOOKS == hook_names
-    valid_content = all([hook.is_guet_hook() for hook in _normal_hooks(hooks)])
-    if (valid_names and valid_content):
-        return [hook for hook in hooks if _name(hook).replace('-guet', '') in hook_names]
-    if not (valid_names and valid_content):
-        hook_names = [_name(hook).replace('-guet', '') for hook in _dash_guet_normal_hooks(hooks)]
+    """Validate a list of hooks and return valid ones."""
+    if not hooks:
+        return []  # early return for empty input
+
+    # first validation
+    normal_hooks = _normal_hooks(hooks)
+    if normal_hooks:  # only validate if normal_hooks is non-empty
+        hook_names = [_name(hook) for hook in normal_hooks]
         valid_names = GUET_HOOKS == hook_names
-        valid_content = all([hook.is_guet_hook() for hook in _dash_guet_normal_hooks(hooks)])
+        valid_content = all(hook.is_guet_hook() for hook in normal_hooks)
         if valid_names and valid_content:
             return [hook for hook in hooks if _name(hook).replace('-guet', '') in hook_names]
+
+    # second validation
+    dash_guet_hooks = _dash_guet_normal_hooks(hooks)
+    if dash_guet_hooks:  # only validate if dash_guet_hooks is non-empty
+        hook_names = [_name(hook).replace('-guet', '') for hook in dash_guet_hooks]
+        valid_names = GUET_HOOKS == hook_names
+        valid_content = all(hook.is_guet_hook() for hook in dash_guet_hooks)
+        if valid_names and valid_content:
+            return [hook for hook in hooks if _name(hook).replace('-guet', '') in hook_names]
+
     return []

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -221,6 +221,19 @@ class TestGit(TestCase):
         git.hooks = []
         self.assertFalse(git.non_guet_hooks_present())
 
+    def test_hooks_present_returns_false_for_empty_hooks(self, _1, _2):
+        git = Git(self.path_to_git)
+        git.hooks = []
+        self.assertFalse(git.hooks_present(), "hooks_present should return False when hooks list is empty")
+
+    def test_hooks_present_returns_false_for_invalid_hooks(self, _1, _2):
+        git = Git(self.path_to_git)
+        git.hooks = [
+            _mock_hook(join(str(self.path_to_git), 'hooks', 'invalid-hook'), is_guet_hook=False),
+            _mock_hook(join(str(self.path_to_git), 'hooks', 'another-hook'), is_guet_hook=False)
+        ]
+        self.assertFalse(git.hooks_present(), "hooks_present should return False when hooks are invalid")
+
     def test_create_hooks_adds_new_files(self, mock_hook, _2):
         git = Git(self.path_to_git)
         git.hooks = []


### PR DESCRIPTION
This PR does:

- Adds checks to valid_hooks to avoid all([]) returning True for empty hook lists.
- Adds tests to ensure valid_hooks returns [] for empty or invalid hooks.

It’s good for preventing misleading validation passes when no hooks are provided, as all([]) returns True.